### PR TITLE
Implement Firebase auth flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ npm-debug.log*
 /platforms
 /plugins
 /www
+
+.env

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,0 +1,14 @@
+import { initializeApp } from 'firebase/app'
+import { getAuth } from 'firebase/auth'
+
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID
+}
+
+const app = initializeApp(firebaseConfig)
+export const auth = getAuth(app)

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,16 +1,22 @@
 import { createRouter, createWebHistory } from '@ionic/vue-router';
 import { RouteRecordRaw } from 'vue-router';
-import HomePage from '../views/HomePage.vue'
+import AuthPage from '../views/AuthPage.vue'
+import UserListPage from '../views/UserListPage.vue'
 
 const routes: Array<RouteRecordRaw> = [
   {
     path: '/',
-    redirect: '/home'
+    redirect: '/auth'
   },
   {
-    path: '/home',
-    name: 'Home',
-    component: HomePage
+    path: '/auth',
+    name: 'Auth',
+    component: AuthPage
+  },
+  {
+    path: '/users',
+    name: 'Users',
+    component: UserListPage
   }
 ]
 

--- a/src/views/AuthPage.vue
+++ b/src/views/AuthPage.vue
@@ -1,0 +1,81 @@
+<template>
+  <ion-page>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Login / Register</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <form @submit.prevent="onSubmit">
+        <ion-item>
+          <ion-label position="stacked">Email</ion-label>
+          <ion-input v-model="email" type="email" required></ion-input>
+        </ion-item>
+        <ion-item>
+          <ion-label position="stacked">Password</ion-label>
+          <ion-input v-model="password" type="password" required></ion-input>
+        </ion-item>
+        <ion-row class="ion-margin-top">
+          <ion-col>
+            <ion-button expand="block" type="submit">{{ modeLabel }}</ion-button>
+          </ion-col>
+        </ion-row>
+        <ion-row>
+          <ion-col class="ion-text-center">
+            <ion-button fill="clear" size="small" @click="toggleMode">
+              {{ toggleLabel }}
+            </ion-button>
+          </ion-col>
+        </ion-row>
+      </form>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
+import {
+  IonPage,
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonItem,
+  IonLabel,
+  IonInput,
+  IonButton,
+  IonRow,
+  IonCol
+} from '@ionic/vue'
+import { auth } from '@/firebase'
+import { signInWithEmailAndPassword, createUserWithEmailAndPassword } from 'firebase/auth'
+
+const router = useRouter()
+const email = ref('')
+const password = ref('')
+const isLogin = ref(true)
+
+const modeLabel = computed(() => (isLogin.value ? 'Login' : 'Register'))
+const toggleLabel = computed(() =>
+  isLogin.value ? "Don't have an account? Register" : 'Already have an account? Login'
+)
+
+function toggleMode() {
+  isLogin.value = !isLogin.value
+}
+
+async function onSubmit() {
+  try {
+    if (isLogin.value) {
+      await signInWithEmailAndPassword(auth, email.value, password.value)
+    } else {
+      await createUserWithEmailAndPassword(auth, email.value, password.value)
+    }
+    router.push('/users')
+  } catch (err) {
+    console.error(err)
+    alert('Authentication failed')
+  }
+}
+</script>

--- a/src/views/UserListPage.vue
+++ b/src/views/UserListPage.vue
@@ -1,0 +1,16 @@
+<template>
+  <ion-page>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Users</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <p>User list will appear here.</p>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import { IonPage, IonHeader, IonToolbar, IonTitle, IonContent } from '@ionic/vue'
+</script>


### PR DESCRIPTION
## Summary
- set up Firebase initialization
- add login/register page with email auth
- add placeholder user list page
- wire up routes for auth flow

## Testing
- `npm run lint -- --fix`

------
https://chatgpt.com/codex/tasks/task_b_684434b51488832191916d78bd45f1e7