### PR TITLE
Add user list and chat placeholder

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,5 +1,6 @@
 import { initializeApp } from 'firebase/app'
 import { getAuth } from 'firebase/auth'
+import { getFirestore } from 'firebase/firestore'
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -12,3 +13,5 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig)
 export const auth = getAuth(app)
+export const db = getFirestore(app)
+

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from '@ionic/vue-router';
 import { RouteRecordRaw } from 'vue-router';
 import AuthPage from '../views/AuthPage.vue'
 import UserListPage from '../views/UserListPage.vue'
+import ChatPage from '../views/ChatPage.vue'
 
 const routes: Array<RouteRecordRaw> = [
   {
@@ -17,6 +18,11 @@ const routes: Array<RouteRecordRaw> = [
     path: '/users',
     name: 'Users',
     component: UserListPage
+  },
+  {
+    path: '/chat/:uid',
+    name: 'Chat',
+    component: ChatPage
   }
 ]
 

--- a/src/views/AuthPage.vue
+++ b/src/views/AuthPage.vue
@@ -48,8 +48,9 @@ import {
   IonRow,
   IonCol
 } from '@ionic/vue'
-import { auth } from '@/firebase'
+import { auth, db } from '@/firebase'
 import { signInWithEmailAndPassword, createUserWithEmailAndPassword } from 'firebase/auth'
+import { doc, setDoc } from 'firebase/firestore'
 
 const router = useRouter()
 const email = ref('')
@@ -70,7 +71,15 @@ async function onSubmit() {
     if (isLogin.value) {
       await signInWithEmailAndPassword(auth, email.value, password.value)
     } else {
-      await createUserWithEmailAndPassword(auth, email.value, password.value)
+      const cred = await createUserWithEmailAndPassword(
+        auth,
+        email.value,
+        password.value
+      )
+      await setDoc(doc(db, 'users', cred.user.uid), {
+        uid: cred.user.uid,
+        email: cred.user.email
+      })
     }
     router.push('/users')
   } catch (err) {

--- a/src/views/ChatPage.vue
+++ b/src/views/ChatPage.vue
@@ -1,0 +1,17 @@
+<template>
+  <ion-page>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Chat</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <p>Chat screen placeholder.</p>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import { IonPage, IonHeader, IonToolbar, IonTitle, IonContent } from '@ionic/vue'
+</script>
+

--- a/src/views/UserListPage.vue
+++ b/src/views/UserListPage.vue
@@ -6,11 +6,52 @@
       </ion-toolbar>
     </ion-header>
     <ion-content class="ion-padding">
-      <p>User list will appear here.</p>
+      <ion-list>
+        <ion-item
+          v-for="user in users"
+          :key="user.uid"
+          button
+          @click="openChat(user.uid)"
+        >
+          {{ user.email }}
+        </ion-item>
+      </ion-list>
     </ion-content>
   </ion-page>
 </template>
 
 <script setup lang="ts">
-import { IonPage, IonHeader, IonToolbar, IonTitle, IonContent } from '@ionic/vue'
+import {
+  IonPage,
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonList,
+  IonItem
+} from '@ionic/vue'
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { auth, db } from '@/firebase'
+import { collection, getDocs } from 'firebase/firestore'
+
+const router = useRouter()
+const users = ref<any[]>([])
+
+async function loadUsers() {
+  const snapshot = await getDocs(collection(db, 'users'))
+  const currentUid = auth.currentUser?.uid
+  users.value = snapshot.docs
+    .map((d) => d.data())
+    .filter((u) => u.uid !== currentUid)
+}
+
+function openChat(uid: string) {
+  router.push(`/chat/${uid}`)
+}
+
+onMounted(() => {
+  loadUsers()
+})
 </script>
+


### PR DESCRIPTION
## Summary
- register users in Firestore after sign-up
- list other users and navigate to chat
- add placeholder chat screen
- register chat route and export Firestore instance

## Testing
- `npm run lint -- --fix`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_b_6844473af14883219c26972715ec9239