### PR TITLE
Improve UI and add logout header

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -15,6 +15,7 @@
 - For new pages, create a folder in `src/views/`.
 - Register new routes in `src/router/index.js`.
 - Add navigation links in `src/components/SideMenu.vue`.
+- Prefer native Ionic UI components and utilities. Avoid custom CSS unless absolutely required.
 
 ## Branch & PR Process
 - Create a new branch for each feature or fix.

--- a/src/components/UserHeader.vue
+++ b/src/components/UserHeader.vue
@@ -1,0 +1,48 @@
+<template>
+  <ion-header>
+    <ion-toolbar color="primary">
+      <ion-buttons slot="start" v-if="backHref">
+        <ion-back-button :default-href="backHref" />
+      </ion-buttons>
+      <ion-title>{{ title }}</ion-title>
+      <ion-buttons slot="end">
+        <ion-label v-if="userEmail" class="ion-margin-end">{{ userEmail }}</ion-label>
+        <ion-button size="small" @click="logout">Logout</ion-button>
+      </ion-buttons>
+    </ion-toolbar>
+  </ion-header>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { auth } from '@/firebase'
+import { signOut } from 'firebase/auth'
+import {
+  IonHeader,
+  IonToolbar,
+  IonButtons,
+  IonBackButton,
+  IonButton,
+  IonTitle,
+  IonLabel
+} from '@ionic/vue'
+
+interface Props {
+  title: string
+  backHref?: string
+}
+
+defineProps<Props>()
+
+const userEmail = computed(() => auth.currentUser?.email)
+
+function logout() {
+  signOut(auth)
+}
+</script>
+
+<style scoped>
+ion-label {
+  font-weight: 500;
+}
+</style>

--- a/src/views/AuthPage.vue
+++ b/src/views/AuthPage.vue
@@ -1,33 +1,39 @@
 <template>
   <ion-page>
     <ion-header>
-      <ion-toolbar>
-        <ion-title>Login / Register</ion-title>
+      <ion-toolbar color="primary">
+        <ion-title>{{ modeLabel }}</ion-title>
       </ion-toolbar>
     </ion-header>
     <ion-content class="ion-padding">
-      <form @submit.prevent="onSubmit">
-        <ion-item>
-          <ion-label position="stacked">Email</ion-label>
-          <ion-input v-model="email" type="email" required></ion-input>
-        </ion-item>
-        <ion-item>
-          <ion-label position="stacked">Password</ion-label>
-          <ion-input v-model="password" type="password" required></ion-input>
-        </ion-item>
-        <ion-row class="ion-margin-top">
-          <ion-col>
-            <ion-button expand="block" type="submit">{{ modeLabel }}</ion-button>
-          </ion-col>
-        </ion-row>
-        <ion-row>
-          <ion-col class="ion-text-center">
-            <ion-button fill="clear" size="small" @click="toggleMode">
+      <ion-card>
+        <ion-card-header>
+          <ion-card-title>{{ modeLabel }}</ion-card-title>
+        </ion-card-header>
+        <ion-card-content>
+          <form @submit.prevent="onSubmit">
+            <ion-item>
+              <ion-label position="stacked">Email</ion-label>
+              <ion-input v-model="email" type="email" required></ion-input>
+            </ion-item>
+            <ion-item>
+              <ion-label position="stacked">Password</ion-label>
+              <ion-input v-model="password" type="password" required></ion-input>
+            </ion-item>
+            <ion-button expand="block" type="submit" class="ion-margin-top">{{
+              modeLabel
+            }}</ion-button>
+            <ion-button
+              fill="clear"
+              size="small"
+              @click="toggleMode"
+              class="ion-margin-top"
+            >
               {{ toggleLabel }}
             </ion-button>
-          </ion-col>
-        </ion-row>
-      </form>
+          </form>
+        </ion-card-content>
+      </ion-card>
     </ion-content>
   </ion-page>
 </template>
@@ -45,8 +51,10 @@ import {
   IonLabel,
   IonInput,
   IonButton,
-  IonRow,
-  IonCol
+  IonCard,
+  IonCardHeader,
+  IonCardTitle,
+  IonCardContent
 } from '@ionic/vue'
 import { auth, db } from '@/firebase'
 import { signInWithEmailAndPassword, createUserWithEmailAndPassword } from 'firebase/auth'
@@ -88,3 +96,10 @@ async function onSubmit() {
   }
 }
 </script>
+
+<style scoped>
+ion-card {
+  max-width: 400px;
+  margin: auto;
+}
+</style>

--- a/src/views/ChatPage.vue
+++ b/src/views/ChatPage.vue
@@ -1,21 +1,20 @@
 <template>
   <ion-page>
-    <ion-header>
-      <ion-toolbar>
-        <ion-buttons slot="start">
-          <ion-back-button default-href="/users" />
-        </ion-buttons>
-        <ion-title>{{ otherUser?.email || 'Chat' }}</ion-title>
-      </ion-toolbar>
-    </ion-header>
+    <user-header :title="otherUser?.email || 'Chat'" back-href="/users" />
     <ion-content class="ion-padding">
       <ion-list>
-        <ion-item v-for="msg in messages" :key="msg.id">
+        <ion-item
+          v-for="msg in messages"
+          :key="msg.id"
+          lines="none"
+          class="message"
+          :class="{ mine: msg.from === currentUid }"
+        >
           <ion-label>
-            <div>
+            <div class="bubble">
               <strong>{{ msg.from === currentUid ? 'Me' : otherUser?.email }}</strong>
+              <div>{{ msg.text }}</div>
             </div>
-            <div>{{ msg.text }}</div>
           </ion-label>
         </ion-item>
       </ion-list>
@@ -32,18 +31,14 @@
 <script setup lang="ts">
 import {
   IonPage,
-  IonHeader,
-  IonToolbar,
-  IonTitle,
   IonContent,
   IonItem,
   IonInput,
   IonButton,
   IonList,
-  IonLabel,
-  IonBackButton,
-  IonButtons
+  IonLabel
 } from '@ionic/vue'
+import UserHeader from '@/components/UserHeader.vue'
 import { ref, onMounted, onUnmounted, computed, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { auth, db } from '@/firebase'
@@ -123,3 +118,20 @@ async function sendMessage() {
   newMessage.value = ''
 }
 </script>
+
+<style scoped>
+.message {
+  --inner-padding-end: 0;
+}
+
+.bubble {
+  background: var(--ion-color-light);
+  border-radius: 8px;
+  padding: 8px;
+}
+
+.message.mine .bubble {
+  background: var(--ion-color-primary);
+  color: white;
+}
+</style>

--- a/src/views/UserListPage.vue
+++ b/src/views/UserListPage.vue
@@ -1,10 +1,6 @@
 <template>
   <ion-page>
-    <ion-header>
-      <ion-toolbar>
-        <ion-title>Users</ion-title>
-      </ion-toolbar>
-    </ion-header>
+    <user-header title="Users" />
     <ion-content class="ion-padding">
       <ion-list>
         <ion-item
@@ -23,13 +19,11 @@
 <script setup lang="ts">
 import {
   IonPage,
-  IonHeader,
-  IonToolbar,
-  IonTitle,
   IonContent,
   IonList,
   IonItem
 } from '@ionic/vue'
+import UserHeader from '@/components/UserHeader.vue'
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { auth, db } from '@/firebase'
@@ -54,4 +48,10 @@ onMounted(() => {
   loadUsers()
 })
 </script>
+
+<style scoped>
+ion-item {
+  --padding-start: 16px;
+}
+</style>
 


### PR DESCRIPTION
## Summary
- create `UserHeader` component showing logged-in info with optional back button
- style authentication form in a card
- style user list and chat message bubbles
- add logout button and user info to user list and chat pages

## Testing
- `npm run lint`
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684469c7ea8c8321a23d7f1e9e594115