### PR TITLE
Apply greyscale theme and logout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ npm-debug.log*
 /www
 
 .env
+.firebase

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -26,3 +26,14 @@
   --ion-color-dark-contrast: #ffffff;
   --ion-color-dark-contrast-rgb: 255, 255, 255;
 }
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ion-color-primary: #ffffff;
+    --ion-color-primary-rgb: 255, 255, 255;
+    --ion-color-primary-contrast: #000000;
+    --ion-color-primary-contrast-rgb: 0, 0, 0;
+    --ion-color-primary-shade: #e6e6e6;
+    --ion-color-primary-tint: #ffffff;
+  }
+}

--- a/src/theme/variables.css
+++ b/src/theme/variables.css
@@ -1,2 +1,28 @@
-/* For information on how to create your own theme, please see:
-http://ionicframework.com/docs/theming/ */
+:root {
+  --ion-background-color: #ffffff;
+  --ion-background-color-rgb: 255, 255, 255;
+  --ion-text-color: #000000;
+  --ion-text-color-rgb: 0, 0, 0;
+
+  --ion-color-primary: #000000;
+  --ion-color-primary-rgb: 0, 0, 0;
+  --ion-color-primary-contrast: #ffffff;
+  --ion-color-primary-contrast-rgb: 255, 255, 255;
+  --ion-color-primary-shade: #1a1a1a;
+  --ion-color-primary-tint: #333333;
+
+  --ion-color-light: #f4f4f4;
+  --ion-color-light-rgb: 244, 244, 244;
+  --ion-color-light-contrast: #000000;
+  --ion-color-light-contrast-rgb: 0, 0, 0;
+
+  --ion-color-medium: #b5b5b5;
+  --ion-color-medium-rgb: 181, 181, 181;
+  --ion-color-medium-contrast: #000000;
+  --ion-color-medium-contrast-rgb: 0, 0, 0;
+
+  --ion-color-dark: #000000;
+  --ion-color-dark-rgb: 0, 0, 0;
+  --ion-color-dark-contrast: #ffffff;
+  --ion-color-dark-contrast-rgb: 255, 255, 255;
+}

--- a/src/views/ChatPage.vue
+++ b/src/views/ChatPage.vue
@@ -6,6 +6,11 @@
           <ion-back-button default-href="/users" />
         </ion-buttons>
         <ion-title>{{ otherUser?.email || 'Chat' }}</ion-title>
+        <ion-buttons slot="end">
+          <ion-button @click="logout">
+            <ion-icon :icon="logOutOutline" />
+          </ion-button>
+        </ion-buttons>
       </ion-toolbar>
     </ion-header>
     <ion-content class="ion-padding">
@@ -42,10 +47,11 @@ import {
   IonList,
   IonLabel,
   IonBackButton,
-  IonButtons
+  IonButtons,
+  IonIcon
 } from '@ionic/vue'
 import { ref, onMounted, onUnmounted, computed, watch } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { auth, db } from '@/firebase'
 import {
   collection,
@@ -57,9 +63,11 @@ import {
   doc,
   getDoc
 } from 'firebase/firestore'
-import { onAuthStateChanged } from 'firebase/auth'
+import { onAuthStateChanged, signOut } from 'firebase/auth'
+import { logOutOutline } from 'ionicons/icons'
 
 const route = useRoute()
+const router = useRouter()
 const otherUid = route.params.uid as string
 const currentUid = ref(auth.currentUser?.uid || '')
 const otherUser = ref<any | null>(null)
@@ -110,6 +118,11 @@ watch(currentUid, (uid) => {
 onUnmounted(() => {
   if (unsubMessages) unsubMessages()
 })
+
+async function logout() {
+  await signOut(auth)
+  router.push('/auth')
+}
 
 async function sendMessage() {
   if (!newMessage.value.trim()) return

--- a/src/views/UserListPage.vue
+++ b/src/views/UserListPage.vue
@@ -3,6 +3,11 @@
     <ion-header>
       <ion-toolbar>
         <ion-title>Users</ion-title>
+        <ion-buttons slot="end">
+          <ion-button @click="logout">
+            <ion-icon :icon="logOutOutline" />
+          </ion-button>
+        </ion-buttons>
       </ion-toolbar>
     </ion-header>
     <ion-content class="ion-padding">
@@ -28,12 +33,17 @@ import {
   IonTitle,
   IonContent,
   IonList,
-  IonItem
+  IonItem,
+  IonButtons,
+  IonButton,
+  IonIcon
 } from '@ionic/vue'
 import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { auth, db } from '@/firebase'
 import { collection, getDocs } from 'firebase/firestore'
+import { signOut } from 'firebase/auth'
+import { logOutOutline } from 'ionicons/icons'
 
 const router = useRouter()
 const users = ref<any[]>([])
@@ -48,6 +58,11 @@ async function loadUsers() {
 
 function openChat(uid: string) {
   router.push(`/chat/${uid}`)
+}
+
+async function logout() {
+  await signOut(auth)
+  router.push('/auth')
 }
 
 onMounted(() => {

--- a/tests/unit/chatpage.spec.ts
+++ b/tests/unit/chatpage.spec.ts
@@ -28,7 +28,10 @@ vi.mock('firebase/firestore', () => ({
 
 vi.mock('firebase/auth', () => ({ onAuthStateChanged: vi.fn() }))
 
-vi.mock('vue-router', () => ({ useRoute: () => ({ params: { uid: 'u2' } }) }))
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { uid: 'u2' } }),
+  useRouter: () => ({ push: vi.fn() })
+}))
 
 describe('ChatPage', () => {
   test('displays messages from snapshot', async () => {


### PR DESCRIPTION
## Summary
- switch Ionic theme to black and white/greyscale
- add logout buttons to user list and chat screens
- update unit test mock for vue-router

## Testing
- `npm run lint --fix`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_b_68446d1ea4888321b8622b297ae31a7a