### PR TITLE
Implement Firebase security and auth guard

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -12,5 +12,8 @@
         "destination": "/index.html"
       }
     ]
+  },
+  "firestore": {
+    "rules": "firestore.rules"
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,15 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{userId} {
+      allow read: if request.auth != null;
+      allow write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    match /messages/{messageId} {
+      allow read: if request.auth != null && (request.auth.uid == resource.data.from || request.auth.uid == resource.data.to);
+      allow create: if request.auth != null && request.auth.uid == request.resource.data.from && (request.resource.data.from == request.auth.uid || request.resource.data.to == request.auth.uid);
+      allow update, delete: if false;
+    }
+  }
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,7 @@
-import { createRouter, createWebHistory } from '@ionic/vue-router';
-import { RouteRecordRaw } from 'vue-router';
+import { createRouter, createWebHistory } from '@ionic/vue-router'
+import { RouteRecordRaw } from 'vue-router'
+import { onAuthStateChanged } from 'firebase/auth'
+import { auth } from '@/firebase'
 import AuthPage from '../views/AuthPage.vue'
 import UserListPage from '../views/UserListPage.vue'
 import ChatPage from '../views/ChatPage.vue'
@@ -29,6 +31,32 @@ const routes: Array<RouteRecordRaw> = [
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes
+})
+
+function getCurrentUser() {
+  return new Promise<any>((resolve, reject) => {
+    const removeListener = onAuthStateChanged(
+      auth,
+      (user) => {
+        removeListener()
+        resolve(user)
+      },
+      reject
+    )
+  })
+}
+
+router.beforeEach(async (to, from, next) => {
+  if (to.name === 'Auth') {
+    return next()
+  }
+
+  const user = auth.currentUser || (await getCurrentUser())
+  if (user) {
+    next()
+  } else {
+    next('/auth')
+  }
 })
 
 export default router


### PR DESCRIPTION
## Summary
- secure Firestore access by adding a `firestore.rules` file
- link the new rules in `firebase.json`
- protect routes behind Firebase auth

## Testing
- `npm run lint --fix`
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6844715727688321aa845c344d94af60