### PR TITLE
Add Ionic loading states

### DIFF
--- a/src/views/AuthPage.vue
+++ b/src/views/AuthPage.vue
@@ -17,7 +17,10 @@
         </ion-item>
         <ion-row class="ion-margin-top">
           <ion-col>
-            <ion-button expand="block" type="submit">{{ modeLabel }}</ion-button>
+            <ion-button expand="block" type="submit" :disabled="loading">
+              <ion-spinner v-if="loading" slot="start" name="crescent" />
+              {{ submitLabel }}
+            </ion-button>
           </ion-col>
         </ion-row>
         <ion-row>
@@ -46,7 +49,8 @@ import {
   IonInput,
   IonButton,
   IonRow,
-  IonCol
+  IonCol,
+  IonSpinner
 } from '@ionic/vue'
 import { auth, db } from '@/firebase'
 import { signInWithEmailAndPassword, createUserWithEmailAndPassword } from 'firebase/auth'
@@ -56,8 +60,12 @@ const router = useRouter()
 const email = ref('')
 const password = ref('')
 const isLogin = ref(true)
+const loading = ref(false)
 
 const modeLabel = computed(() => (isLogin.value ? 'Login' : 'Register'))
+const submitLabel = computed(() =>
+  loading.value ? (isLogin.value ? 'Logging in' : 'Registering') : modeLabel.value
+)
 const toggleLabel = computed(() =>
   isLogin.value ? "Don't have an account? Register" : 'Already have an account? Login'
 )
@@ -67,6 +75,7 @@ function toggleMode() {
 }
 
 async function onSubmit() {
+  loading.value = true
   try {
     if (isLogin.value) {
       await signInWithEmailAndPassword(auth, email.value, password.value)
@@ -85,6 +94,8 @@ async function onSubmit() {
   } catch (err) {
     console.error(err)
     alert('Authentication failed')
+  } finally {
+    loading.value = false
   }
 }
 </script>

--- a/src/views/ChatPage.vue
+++ b/src/views/ChatPage.vue
@@ -14,7 +14,15 @@
       </ion-toolbar>
     </ion-header>
     <ion-content class="ion-padding">
-      <ion-list>
+      <ion-loading :is-open="loadingUser" message="Loading chat..." />
+      <ion-list v-if="loadingMessages">
+        <ion-item v-for="n in 5" :key="n">
+          <ion-label>
+            <ion-skeleton-text animated style="width: 100%" />
+          </ion-label>
+        </ion-item>
+      </ion-list>
+      <ion-list v-else>
         <ion-item v-for="msg in messages" :key="msg.id">
           <ion-label>
             <div>
@@ -48,7 +56,8 @@ import {
   IonLabel,
   IonBackButton,
   IonButtons,
-  IonIcon
+  IonIcon,
+  IonSkeletonText
 } from '@ionic/vue'
 import { ref, onMounted, onUnmounted, computed, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
@@ -73,6 +82,8 @@ const currentUid = ref(auth.currentUser?.uid || '')
 const otherUser = ref<any | null>(null)
 const newMessage = ref('')
 const messages = ref<any[]>([])
+const loadingMessages = ref(true)
+const loadingUser = ref(true)
 
 const chatId = computed(() => [currentUid.value, otherUid].sort().join('_'))
 
@@ -81,6 +92,7 @@ let unsubMessages: (() => void) | null = null
 async function startListener() {
   if (unsubMessages) unsubMessages()
   const q = query(collection(db, 'messages'), where('chatId', '==', chatId.value))
+  loadingMessages.value = true
   unsubMessages = onSnapshot(q, (snapshot) => {
     messages.value = snapshot.docs
       .map((d) => ({ id: d.id, ...d.data() }))
@@ -89,6 +101,7 @@ async function startListener() {
         const bTime = (b as any).createdAt?.seconds || 0
         return aTime - bTime
       }) as any[]
+    loadingMessages.value = false
   })
 }
 
@@ -97,6 +110,7 @@ onMounted(async () => {
   if (userSnap.exists()) {
     otherUser.value = userSnap.data()
   }
+  loadingUser.value = false
 
   if (currentUid.value) {
     startListener()

--- a/src/views/UserListPage.vue
+++ b/src/views/UserListPage.vue
@@ -11,7 +11,12 @@
       </ion-toolbar>
     </ion-header>
     <ion-content class="ion-padding">
-      <ion-list>
+      <ion-list v-if="loading">
+        <ion-item v-for="n in 5" :key="n">
+          <ion-skeleton-text animated style="width: 100%" />
+        </ion-item>
+      </ion-list>
+      <ion-list v-else>
         <ion-item
           v-for="user in users"
           :key="user.uid"
@@ -34,6 +39,7 @@ import {
   IonContent,
   IonList,
   IonItem,
+  IonSkeletonText,
   IonButtons,
   IonButton,
   IonIcon
@@ -47,13 +53,16 @@ import { logOutOutline } from 'ionicons/icons'
 
 const router = useRouter()
 const users = ref<any[]>([])
+const loading = ref(true)
 
 async function loadUsers() {
+  loading.value = true
   const snapshot = await getDocs(collection(db, 'users'))
   const currentUid = auth.currentUser?.uid
   users.value = snapshot.docs
     .map((d) => d.data())
     .filter((u) => u.uid !== currentUid)
+  loading.value = false
 }
 
 function openChat(uid: string) {


### PR DESCRIPTION
## Summary
- show ion-loading on auth submit
- add skeleton items to user list
- add loading skeletons and spinners to chat page
- adjust auth submit button label

## Testing
- `npm run lint --silent --fix`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_b_684471d267ec83218118740c19a371dd