### PR TITLE
Add FCM push notification support

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,7 +1,5 @@
-import { initializeApp } from 'firebase/app'
-import { getAuth } from 'firebase/auth'
-import { getFirestore } from 'firebase/firestore'
-import { getMessaging } from 'firebase/messaging'
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-app.js'
+import { getMessaging, onBackgroundMessage } from 'https://www.gstatic.com/firebasejs/11.9.0/firebase-messaging-sw.js'
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -13,7 +11,8 @@ const firebaseConfig = {
 }
 
 const app = initializeApp(firebaseConfig)
-export const auth = getAuth(app)
-export const db = getFirestore(app)
-export const messaging = getMessaging(app)
+const messaging = getMessaging(app)
 
+onBackgroundMessage(messaging, payload => {
+  console.log('[Service Worker] Background message received', payload)
+})


### PR DESCRIPTION
## Summary
- integrate Firebase Messaging in `firebase.ts`
- register a Firebase messaging service worker
- show toast to enable push and request permission via FCM on UserListPage

## Testing
- `npm run lint`
- `npm run test:unit` *(cancelled watch mode after pass)*

------
https://chatgpt.com/codex/tasks/task_b_684472a290ec8321b13d8a57210140ef