### PR TITLE
Refactor chat storage for unique 1-1 threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Vibe App
+
+## Migration to /chats Structure
+
+Older versions stored all messages in a root `messages` collection with `chatId`, `from`, and `to` fields. The app now uses a `chats` collection where each document lists the two participants and contains a `messages` subcollection. Each chat document ID is the two participant UIDs sorted and joined with an underscore (e.g. `uidA_uidB`).
+
+To migrate existing messages:
+
+1. For each document in `messages`, create a chat document in `/chats/{chatId}` where `chatId` is `[from, to].sort().join('_')` with:
+   - `participants: [from, to]`
+   - `createdAt: original message timestamp`
+2. Move the message document into `/chats/{chatId}/messages/{messageId}` and remove the `chatId` and `to` fields.
+3. After verifying data, delete the old `messages` collection.
+
+A simple Node script can be written using the Firebase Admin SDK to automate this.

--- a/agents.md
+++ b/agents.md
@@ -25,4 +25,19 @@
 ## Setup & Testing
 - Always run `npm install` before any other command.
 - Lint code with `npm run lint`.
-- (Optional) Run tests with `npm run test`.
+ 
+## Test Users for Automated Testing
+
+- Use the following environment variables to specify test users for authentication and chat tests:
+  - `TEST_USER_EMAIL` / `TEST_USER_PASSWORD`: The primary test user (sender).
+  - `TEST_RECIPIENT_EMAIL` / `TEST_RECIPIENT_PASSWORD`: The recipient test user.
+- Always use these credentials when writing tests or automated scripts involving chat flows (sending, receiving, querying chat history).
+- Do **not** hardcode these credentials; always read from environment variables.
+- Example usage:
+
+  ```js
+  const senderEmail = process.env.TEST_USER_EMAIL;
+  const senderPassword = process.env.TEST_USER_PASSWORD;
+  const recipientEmail = process.env.TEST_RECIPIENT_EMAIL;
+  const recipientPassword = process.env.TEST_RECIPIENT_PASSWORD;
+  // Use these for chat tests: sender sends, recipient receives

--- a/firestore.rules
+++ b/firestore.rules
@@ -6,10 +6,18 @@ service cloud.firestore {
       allow write: if request.auth != null && request.auth.uid == userId;
     }
 
-    match /messages/{messageId} {
-      allow read: if request.auth != null && (request.auth.uid == resource.data.from || request.auth.uid == resource.data.to);
-      allow create: if request.auth != null && request.auth.uid == request.resource.data.from && (request.resource.data.from == request.auth.uid || request.resource.data.to == request.auth.uid);
+    match /chats/{chatId} {
+      allow read: if request.auth != null && request.auth.uid in resource.data.participants;
+      allow create: if request.auth != null &&
+        request.resource.data.participants is list &&
+        request.resource.data.participants.size() == 2 &&
+        request.auth.uid in request.resource.data.participants;
       allow update, delete: if false;
+
+      match /messages/{messageId} {
+        allow read, write: if request.auth != null && request.auth.uid in get(/databases/$(database)/documents/chats/$(chatId)).data.participants;
+        allow update, delete: if false;
+      }
     }
   }
 }

--- a/tests/unit/chatpage.spec.ts
+++ b/tests/unit/chatpage.spec.ts
@@ -8,14 +8,14 @@ vi.mock('@/firebase', () => ({
 }))
 
 const mockMessages = [
-  { id: '1', chatId: 'u1_u2', from: 'u1', to: 'u2', text: 'Hello', createdAt: { seconds: 1 } },
-  { id: '2', chatId: 'u1_u2', from: 'u2', to: 'u1', text: 'Hi there', createdAt: { seconds: 2 } }
+  { id: '1', from: 'u1', text: 'Hello', createdAt: { seconds: 1 } },
+  { id: '2', from: 'u2', text: 'Hi there', createdAt: { seconds: 2 } }
 ]
 
 vi.mock('firebase/firestore', () => ({
   collection: vi.fn(),
   query: vi.fn(),
-  where: vi.fn(),
+  orderBy: vi.fn(),
   onSnapshot: (_q: any, cb: any) => {
     cb({ docs: mockMessages.map((m) => ({ id: m.id, data: () => m })) })
     return vi.fn()
@@ -23,7 +23,8 @@ vi.mock('firebase/firestore', () => ({
   addDoc: vi.fn(),
   serverTimestamp: vi.fn(),
   doc: vi.fn(),
-  getDoc: vi.fn(() => Promise.resolve({ exists: () => true, data: () => ({ email: 'other@example.com' }) }))
+  getDoc: vi.fn(() => Promise.resolve({ exists: () => true, data: () => ({ email: 'other@example.com' }) })),
+  setDoc: vi.fn()
 }))
 
 vi.mock('firebase/auth', () => ({ onAuthStateChanged: vi.fn() }))


### PR DESCRIPTION
## Summary
- enforce deterministic chatId creation
- remove unused chat list view and route
- redirect login to user list
- tighten Firestore security rules
- document migration steps

## Testing
- `npm run lint --fix`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_b_684489d8117c8321bbc5d5548233a1d2