### PR TITLE
Improve chat error handling

### DIFF
--- a/tests/unit/chatpage.spec.ts
+++ b/tests/unit/chatpage.spec.ts
@@ -17,7 +17,8 @@ vi.mock('firebase/firestore', () => ({
   query: vi.fn(),
   where: vi.fn(),
   onSnapshot: (_q: any, cb: any) => {
-    cb({ docs: mockMessages.map((m) => ({ id: m.id, data: () => m })) })
+    const next = typeof cb === 'function' ? cb : cb.next
+    next({ docs: mockMessages.map((m) => ({ id: m.id, data: () => m })) })
     return vi.fn()
   },
   addDoc: vi.fn(),
@@ -46,6 +47,7 @@ describe('ChatPage', () => {
           IonLabel: slotStub,
           IonLoading: slotStub,
           IonSkeletonText: slotStub,
+          IonText: slotStub,
           IonBackButton: slotStub,
           IonButtons: slotStub,
           IonIcon: slotStub,
@@ -72,6 +74,7 @@ describe('ChatPage', () => {
           IonLabel: slotStub,
           IonLoading: slotStub,
           IonSkeletonText: slotStub,
+          IonText: slotStub,
           IonBackButton: slotStub,
           IonButtons: slotStub,
           IonIcon: slotStub,


### PR DESCRIPTION
## Summary
- add IonText warning on ChatPage when message loading fails
- log Firestore listener errors
- test ChatPage with new IonText stub

## Testing
- `npm run test:unit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_684588b699508321b1a91fd4d8328c69