### PR TITLE
Implement offline message caching and persistence

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,6 +1,6 @@
 import { initializeApp } from 'firebase/app'
 import { getAuth } from 'firebase/auth'
-import { getFirestore } from 'firebase/firestore'
+import { getFirestore, enableIndexedDbPersistence } from 'firebase/firestore'
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -14,4 +14,8 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig)
 export const auth = getAuth(app)
 export const db = getFirestore(app)
+
+enableIndexedDbPersistence(db).catch((err) => {
+  console.warn('IndexedDB persistence failed, continuing without it', err)
+})
 

--- a/tests/unit/chatpage.spec.ts
+++ b/tests/unit/chatpage.spec.ts
@@ -52,7 +52,12 @@ describe('ChatPage', () => {
           IonButtons: slotStub,
           IonIcon: slotStub,
           IonInput: slotStub,
-          IonButton: slotStub
+          IonButton: slotStub,
+          IonItemSliding: slotStub,
+          IonItemOptions: slotStub,
+          IonItemOption: slotStub,
+          IonChip: slotStub,
+          IonSpinner: slotStub
         }
       }
     })
@@ -79,7 +84,12 @@ describe('ChatPage', () => {
           IonButtons: slotStub,
           IonIcon: slotStub,
           IonInput: slotStub,
-          IonButton: slotStub
+          IonButton: slotStub,
+          IonItemSliding: slotStub,
+          IonItemOptions: slotStub,
+          IonItemOption: slotStub,
+          IonChip: slotStub,
+          IonSpinner: slotStub
         }
       }
     })


### PR DESCRIPTION
## Summary
- enable Firestore IndexedDB persistence
- cache chat threads locally and sync queued messages when back online
- show offline chip and spinner
- append queued messages last and display message send time on swipe

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68464a70f7748321b62a50c174befdd4