### PR TITLE
Fix pending writes filtering

### DIFF
--- a/src/views/ChatPage.vue
+++ b/src/views/ChatPage.vue
@@ -225,7 +225,9 @@ async function startListener() {
   const unsubSent = onSnapshot(
     sentQ,
     (snapshot) => {
-      fromMessages = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }))
+      fromMessages = snapshot.docs
+        .filter((d) => !d.metadata.hasPendingWrites)
+        .map((d) => ({ id: d.id, ...d.data() }))
       updateStored()
     },
     onSnapshotError
@@ -233,7 +235,9 @@ async function startListener() {
   const unsubReceived = onSnapshot(
     receivedQ,
     (snapshot) => {
-      toMessages = snapshot.docs.map((d) => ({ id: d.id, ...d.data() }))
+      toMessages = snapshot.docs
+        .filter((d) => !d.metadata.hasPendingWrites)
+        .map((d) => ({ id: d.id, ...d.data() }))
       updateStored()
     },
     onSnapshotError

--- a/tests/unit/chatpage.spec.ts
+++ b/tests/unit/chatpage.spec.ts
@@ -18,7 +18,13 @@ vi.mock('firebase/firestore', () => ({
   where: vi.fn(),
   onSnapshot: (_q: any, cb: any) => {
     const next = typeof cb === 'function' ? cb : cb.next
-    next({ docs: mockMessages.map((m) => ({ id: m.id, data: () => m })) })
+    next({
+      docs: mockMessages.map((m) => ({
+        id: m.id,
+        data: () => m,
+        metadata: { hasPendingWrites: false }
+      }))
+    })
     return vi.fn()
   },
   addDoc: vi.fn(),


### PR DESCRIPTION
## Summary
- filter pending writes when listening for messages
- update chat page unit test mock metadata so tests pass

## Testing
- `npm run lint`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_b_684b73e91c2483219d05ea5b613bde30