### PR TITLE
Add Firebase push notifications

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,0 +1,22 @@
+/* eslint-disable no-undef */
+importScripts('https://www.gstatic.com/firebasejs/11.9.0/firebase-app-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/11.9.0/firebase-messaging-compat.js');
+
+firebase.initializeApp({
+  apiKey: "VITE_FIREBASE_API_KEY",
+  authDomain: "VITE_FIREBASE_AUTH_DOMAIN",
+  projectId: "VITE_FIREBASE_PROJECT_ID",
+  storageBucket: "VITE_FIREBASE_STORAGE_BUCKET",
+  messagingSenderId: "VITE_FIREBASE_MESSAGING_SENDER_ID",
+  appId: "VITE_FIREBASE_APP_ID"
+});
+
+const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage((payload) => {
+  const { title, body } = payload.notification || {};
+  self.registration.showNotification(title ?? 'Notification', {
+    body: body ?? 'You have a new message.',
+    icon: '/android-icon-192x192.png'
+  });
+});

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,25 @@
 <template>
   <ion-app>
     <ion-router-outlet />
+    <ion-toast :is-open="showToast" :message="toastMessage" @didDismiss="showToast = false" />
   </ion-app>
 </template>
 
 <script setup lang="ts">
-import { IonApp, IonRouterOutlet } from '@ionic/vue';
+import { ref, onMounted } from 'vue'
+import { IonApp, IonRouterOutlet, IonToast } from '@ionic/vue'
+import { registerForPushNotifications, listenToForegroundMessages } from '@/hooks/useNotifications'
+
+const toastMessage = ref('')
+const showToast = ref(false)
+
+onMounted(() => {
+  registerForPushNotifications()
+  listenToForegroundMessages((payload) => {
+    const title = payload.notification?.title || ''
+    const body = payload.notification?.body || ''
+    toastMessage.value = title ? `${title}: ${body}` : body
+    showToast.value = true
+  })
+})
 </script>

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -11,7 +11,7 @@ const firebaseConfig = {
   appId: import.meta.env.VITE_FIREBASE_APP_ID
 }
 
-const app = initializeApp(firebaseConfig)
+export const app = initializeApp(firebaseConfig)
 export const auth = getAuth(app)
 export const db = getFirestore(app)
 

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,0 +1,31 @@
+import { messaging } from '@/lib/firebaseMessaging'
+import { getToken, onMessage } from 'firebase/messaging'
+import { doc, updateDoc } from 'firebase/firestore'
+import { db, auth } from '@/firebase'
+
+const vapidKey = import.meta.env.VITE_FIREBASE_VAPID_PUBLIC_KEY
+
+export async function registerForPushNotifications() {
+  if (Notification.permission !== 'granted') {
+    const permission = await Notification.requestPermission()
+    if (permission !== 'granted') return
+  }
+
+  try {
+    const registration = await navigator.serviceWorker.register('/firebase-messaging-sw.js')
+    const token = await getToken(messaging, { vapidKey, serviceWorkerRegistration: registration })
+    const user = auth.currentUser
+    if (user && token) {
+      await updateDoc(doc(db, 'users', user.uid), { fcmToken: token })
+    }
+  } catch (err) {
+    console.error('Push setup failed', err)
+  }
+}
+
+export function listenToForegroundMessages(callback?: (payload: any) => void) {
+  onMessage(messaging, (payload) => {
+    console.log('Foreground message:', payload)
+    callback?.(payload)
+  })
+}

--- a/src/lib/firebaseMessaging.ts
+++ b/src/lib/firebaseMessaging.ts
@@ -1,0 +1,4 @@
+import { getMessaging } from "firebase/messaging";
+import { app } from "../firebase";
+
+export const messaging = getMessaging(app);

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,6 +5,8 @@ import { useAuth } from '@/store/auth'
 import AuthPage from '../views/AuthPage.vue'
 import UserListPage from '../views/UserListPage.vue'
 import ChatPage from '../views/ChatPage.vue'
+import SettingsPage from '../views/SettingsPage.vue'
+import TabsPage from '../views/TabsPage.vue'
 
 const routes: Array<RouteRecordRaw> = [
   {
@@ -17,10 +19,21 @@ const routes: Array<RouteRecordRaw> = [
     component: AuthPage
   },
   {
-    path: '/users',
-    name: 'Users',
-    component: UserListPage,
-    meta: { requiresAuth: true }
+    path: '/',
+    component: TabsPage,
+    meta: { requiresAuth: true },
+    children: [
+      {
+        path: 'users',
+        name: 'Users',
+        component: UserListPage
+      },
+      {
+        path: 'settings',
+        name: 'Settings',
+        component: SettingsPage
+      }
+    ]
   },
   {
     path: '/chat/:uid',

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -1,0 +1,45 @@
+<template>
+  <ion-page>
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Settings</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <ion-item>
+        <ion-label>Enable push notifications</ion-label>
+        <ion-toggle :checked="pushEnabled" :disabled="toggleDisabled" @ionChange="onToggle" />
+      </ion-item>
+      <ion-button color="danger" fill="outline" expand="block" class="ion-margin-top" @click="logout">
+        Logout
+      </ion-button>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { IonPage, IonHeader, IonToolbar, IonTitle, IonContent, IonItem, IonLabel, IonToggle, IonButton } from '@ionic/vue'
+import { auth } from '@/firebase'
+import { signOut } from 'firebase/auth'
+import { registerForPushNotifications } from '@/hooks/useNotifications'
+
+const router = useRouter()
+const pushEnabled = ref(Notification.permission === 'granted')
+const toggleDisabled = computed(() => !('Notification' in window) || !('serviceWorker' in navigator))
+
+async function onToggle(ev: CustomEvent) {
+  if (ev.detail.checked) {
+    await registerForPushNotifications()
+    pushEnabled.value = Notification.permission === 'granted'
+  } else {
+    pushEnabled.value = false
+  }
+}
+
+async function logout() {
+  await signOut(auth)
+  router.replace('/auth')
+}
+</script>

--- a/src/views/TabsPage.vue
+++ b/src/views/TabsPage.vue
@@ -1,0 +1,19 @@
+<template>
+  <ion-page>
+    <ion-tabs>
+      <ion-router-outlet />
+      <ion-tab-bar slot="bottom">
+        <ion-tab-button tab="users" href="/users">
+          <ion-label>Users</ion-label>
+        </ion-tab-button>
+        <ion-tab-button tab="settings" href="/settings">
+          <ion-label>Settings</ion-label>
+        </ion-tab-button>
+      </ion-tab-bar>
+    </ion-tabs>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import { IonPage, IonTabs, IonRouterOutlet, IonTabBar, IonTabButton, IonLabel } from '@ionic/vue'
+</script>


### PR DESCRIPTION
## Summary
- set up FCM messaging helper and service worker
- create notification hooks
- show toast notifications in the main app
- add Settings page with push toggle
- introduce Tabs layout with Users and Settings
- register FCM token and update routes

## Testing
- `npm run lint`
- `npm run build`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_b_684b77e6d1188321b770a0236855a6ec